### PR TITLE
Fix/157210984/ Refactor GET /menu route

### DIFF
--- a/server/src/controllers/menuController.js
+++ b/server/src/controllers/menuController.js
@@ -1,33 +1,17 @@
-import isSameDay from 'date-fns/is_same_day';
 import Controller from './controller';
 
 export default class MenuController extends Controller {
-  constructor(menu, model) {
-    super(model);
-    this.menu = menu;
-  }
-  getTodaysMenu(req) {
-    const queryDate = req.query && req.query.date;
-    const date = queryDate || (new Date());
-    const record = this.menu.find(elem => isSameDay(elem.date, date));
-    if (record) {
-      const recordCopy = { ...record };
-      const mealsArray = [...recordCopy.meals];
-      const expandedMealsArray = mealsArray
-        .map(mealId => super.getSingleRecord({ params: { id: mealId } }).message);
-      recordCopy.meals = expandedMealsArray;
-      return Controller.defaultResponse(recordCopy);
+  getMenu() {
+    if (this.model) {
+      return Controller.defaultResponse(this.model);
     }
     return Controller.errorResponse();
   }
-  postRecord(req) {
-    const now = new Date();
-    req.body.date = now;
-    const recordIndex = this.menu.findIndex(elem => isSameDay(elem.date, now));
-    if (recordIndex >= 0) {
-      this.menu.splice(recordIndex, 1);
+  postMenu(req) {
+    if (this.model) {
+      this.model = req.body;
+      return Controller.defaultResponse(this.model, 201);
     }
-
-    return super.postRecord(req, this.menu);
+    return Controller.errorResponse();
   }
 }

--- a/server/src/middleware/menuSchemas.js
+++ b/server/src/middleware/menuSchemas.js
@@ -1,9 +1,8 @@
 import Joi from 'joi';
 
 const menu = Joi.object({
-  date: Joi.date().min('now').required(),
   description: Joi.string().required(),
-  meals: Joi.array().items(Joi.number().integer().required()).required(),
+  meals: Joi.array().items(Joi.object().required()).required(),
 });
 
 export default menu;

--- a/server/src/models/menus.js
+++ b/server/src/models/menus.js
@@ -1,16 +1,19 @@
-const menus = [
-  {
-    id: 1,
-    date: new Date(Date.UTC(2018, 4, 20)),
-    description: 'Continental, Local',
-    meals: [1, 2]
-  },
-  {
-    id: 2,
-    date: new Date(),
-    description: 'Continental, Local',
-    meals: [2, 1]
-  }
-];
+const menu = {
+  description: 'Continental, Local',
+  meals: [
+    {
+      id: 1,
+      title: 'Beef with Rice',
+      description: 'plain rice with ground beef',
+      price: 1500,
+    },
+    {
+      id: 2,
+      title: 'Beef with Fries',
+      description: 'beef slab with fried potato slivers',
+      price: 2000,
+    },
+  ]
+};
 
-export default menus;
+export default menu;

--- a/server/src/routes/menuRoutes.js
+++ b/server/src/routes/menuRoutes.js
@@ -5,16 +5,15 @@ import Validator from 'express-joi-validation';
 import MenuController from '../controllers/menuController';
 import menuSchema from '../middleware/menuSchemas';
 import menus from '../models/menus';
-import meals from '../models/meals';
 
 const router = express.Router();
 const validator = Validator({});
-const menuController = new MenuController(menus, meals);
+const menuController = new MenuController(menus);
 
 
 router.route('/')
-  .get(MenuController.select(menuController, 'getTodaysMenu'))
-  .post(validator.body(menuSchema), MenuController.select(menuController, 'postRecord'));
+  .get(MenuController.select(menuController, 'getMenu'))
+  .post(validator.body(menuSchema), MenuController.select(menuController, 'postMenu'));
 
 // Return router
 export default router;

--- a/server/test/integration/menu.js
+++ b/server/test/integration/menu.js
@@ -2,30 +2,60 @@ import { expect, request, menuUrl, templateTest } from './helper';
 
 import app from '../../src/app';
 
+const defaultMenu = {
+  description: 'Continental, Local',
+  meals: [
+    {
+      id: 1,
+      title: 'Beef with Rice',
+      description: 'plain rice with ground beef',
+      price: 1500
+    },
+    {
+      id: 2,
+      title: 'Beef with Fries',
+      description: 'beef slab with fried potato slivers',
+      price: 2000
+    }
+  ]
+};
 // Get  Menu
 describe('GET /menu', () => {
   it('should return the menu for today', () =>
-    request(app).get(menuUrl).then((res) => {
-      expect(res.body.date.toString().substring(0, 10))
-        .to.equal(new Date().toISOString().substring(0, 10));
-    }));
+    request(app)
+      .get(menuUrl)
+      .then((res) => {
+        expect(res.body).to.eql(defaultMenu);
+      }));
   templateTest('Get Menu', 'get', menuUrl, null, 'meals', 'object');
 });
 
 // Post Menu
 describe('POST /menu', () => {
   const newMenu = {
-    // date will be set to current date by controller
-    date: '2018-05-25',
-    description: 'Continental, Local',
-    meals: [1, 2]
+    description: 'Thursday Menu',
+    meals: [
+      {
+        id: 3,
+        title: 'Beef with Spaghetti',
+        description: 'spaghetti with ground beef',
+        price: 1500
+      },
+      {
+        id: 2,
+        title: 'Beef with Fries',
+        description: 'beef slab with fried potato slivers',
+        price: 2000
+      }
+    ]
   };
+
   it('should create a menu', () =>
     request(app)
       .post(menuUrl)
       .send(newMenu)
       .then((res) => {
-        expect(res.body.description).to.equal(newMenu.description);
+        expect(res.body).to.eql(newMenu);
       }));
   templateTest('Add Menu', 'post', menuUrl, newMenu, 'meals', 'object', '201');
 });

--- a/server/test/unit/controllers/menuController.js
+++ b/server/test/unit/controllers/menuController.js
@@ -6,70 +6,68 @@ const errorResponse = {
   message: 'records unavailable',
   statusCode: 404
 };
-const menuList = [
-  {
-    id: 1,
-    date: new Date(2019, 11, 1),
-    meals: [1, 2]
-  },
-  {
-    id: 2,
-    date: new Date(),
-    meals: [2, 1]
-  }
-];
-const meals = [
-  {
-    id: 1,
-    title: 'Beef with Rice',
-    description: 'plain rice with ground beef',
-    price: 1500,
-  },
-  {
-    id: 2,
-    title: 'Beef with Fries',
-    description: 'beef slab with fried potato slivers',
-    price: 2000,
-  },
-];
-describe('getTodaysMenu()', () => {
-  const req = {};
-  it('should return a menu when menu with current date exists', () => {
-    const listCopy = [...menuList];
-    const menuController = new MenuController(listCopy, meals);
-    expect(menuController.getTodaysMenu(req).message.id).to.eql(listCopy[1].id);
-  });
-  it('should return error message when no menu with current date exists', () => {
-    const listCopy = [...menuList];
-    listCopy[1].date = new Date(2014, 8, 1);
+const menu = {
+  description: 'Friday Menu',
+  meals: [
+    {
+      id: 1,
+      title: 'Beef with Rice',
+      description: 'plain rice with ground beef',
+      price: 1500
+    },
+    {
+      id: 2,
+      title: 'Beef with Fries',
+      description: 'beef slab with fried potato slivers',
+      price: 2000
+    }
+  ]
+};
 
-    const menuController = new MenuController(listCopy, meals);
-    expect(menuController.getTodaysMenu(req)).to.eql(errorResponse);
+describe('getMenu()', () => {
+  const req = {};
+  it('should return a menu when menu model exists', () => {
+    const menuCopy = { ...menu };
+    const menuController = new MenuController(menuCopy);
+    const expected = {
+      message: { ...menuCopy },
+      statusCode: 200
+    };
+    expect(menuController.getMenu()).to.eql(expected);
+  });
+  it('should return error message when no menu model exists', () => {
+    const menuCopy = null;
+    const menuController = new MenuController(menuCopy);
+    expect(menuController.getMenu(req)).to.eql(errorResponse);
   });
 });
-describe('postRecord()', () => {
-  it('should remove menu with current date before posting another menu with current date', () => {
-    const listCopy = [...menuList];
+describe('postMenu()', () => {
+  it('should set the menu for the day', () => {
     const req = {
-      body: { date: new Date() }
+      body: {
+        description: 'Thursday Menu',
+        meals: [
+          {
+            id: 3,
+            title: 'Beef with Spaghetti',
+            description: 'spaghetti with ground beef',
+            price: 1500
+          },
+          {
+            id: 2,
+            title: 'Beef with Fries',
+            description: 'beef slab with fried potato slivers',
+            price: 2000
+          }
+        ]
+      }
     };
-
-    const menuController = new MenuController(listCopy, meals);
-    const firstPost = menuController.postRecord(req).message.id;
-    const secondPost = menuController.postRecord(req).message.id;
-    expect(firstPost).to.equal(secondPost);
-  });
-  it('should set the date on the menu to the current date', () => {
-    const listCopy = [...menuList];
-    const req = {
-      body: { date: new Date(2020, 3, 4) }
+    const menuCopy = { ...menu };
+    const menuController = new MenuController(menuCopy);
+    const expected = {
+      message: { ...req.body },
+      statusCode: 201
     };
-
-    const menuController = new MenuController(listCopy, meals);
-
-    expect(menuController
-      .postRecord(req)
-      .message.date.toISOString()
-      .substring(0, 10)).to.eql(new Date().toISOString().substring(0, 10));
+    expect(menuController.postMenu(req)).to.eql(expected);
   });
 });

--- a/server/test/unit/validationSchema/menuSchema.js
+++ b/server/test/unit/validationSchema/menuSchema.js
@@ -1,15 +1,25 @@
 /* eslint import/no-extraneous-dependencies: off */
-import {
-  assert
-} from 'chai';
+import { assert } from 'chai';
 import schema from '../../../src/middleware/menuSchemas';
 
 context('Validation with Joi schemas', () => {
   // sample request body data
   const menu = {
-    date: new Date(Date.UTC(2018, 4, 20)),
     description: 'Continental, Local',
-    meals: [1, 2],
+    meals: [
+      {
+        id: 3,
+        title: 'Beef with Spaghetti',
+        description: 'spaghetti with ground beef',
+        price: 1500
+      },
+      {
+        id: 2,
+        title: 'Beef with Fries',
+        description: 'beef slab with fried potato slivers',
+        price: 2000
+      }
+    ]
   };
 
   describe('for POST requests on /api/v1/menu, validation', () => {
@@ -25,12 +35,7 @@ context('Validation with Joi schemas', () => {
       const result = schema.validate(modified);
       assert.notEqual(result.error, null, `Joi output: ${result.error}`);
     });
-    it('throws error when date field is in the past', () => {
-      const modified = { ...menu };
-      modified.date = '2014-3-4';
-      const result = schema.validate(modified);
-      assert.notEqual(result.error, null, `Joi output: ${result.error}`);
-    });
+
     it('does not throw error when all required fields are in request body', () => {
       const result = schema.validate(menu);
       assert.equal(result.error, null, `Joi output: ${result.error}`);


### PR DESCRIPTION
#### What does this PR do?
Modifies the menu dummy DB such that menu is a single object containing meal details
Refactor endpoint controllers and tests to suit model changes

#### Description of Task to be completed?
Build endpoints for GET on the /api/v1/menu endpoint

#### How should this be manually tested?
Start the app with **npm start**
Using Postman import this endpoint collection link https://www.getpostman.com/collections/85eee7927738b7112a13 and test

#### Any background context you want to provide?
Adds the feature:

* Admin (Caterer) should be able to setup menu for a specific day by selecting from the
meal options available on the system.


#### What are the relevant pivotal tracker stories? (If applicable) 
#157210984
#### Screenshots (If applicable)
None