### PR TITLE
#160412932 add loading indicator to menu cart

### DIFF
--- a/client/__tests__/components/__snapshots__/MenuContainer.test.jsx.snap
+++ b/client/__tests__/components/__snapshots__/MenuContainer.test.jsx.snap
@@ -59,12 +59,14 @@ exports[`MenuContainer Component renders correctly 1`] = `
   >
     <button
       className="btn btn-cart"
+      disabled={false}
       onClick={[Function]}
     >
       Post meals to Menu
     </button>
     <button
       className="btn btn-cart"
+      disabled={false}
       onClick={[MockFunction]}
     >
       Clear Menu
@@ -132,12 +134,14 @@ exports[`MenuContainer Component renders correctly 2`] = `
   >
     <button
       className="btn btn-cart"
+      disabled={false}
       onClick={[Function]}
     >
       Post meals to Menu
     </button>
     <button
       className="btn btn-cart"
+      disabled={false}
       onClick={[MockFunction]}
     >
       Clear Menu

--- a/client/src/components/orderCart/ConnectedMenuContainer.jsx
+++ b/client/src/components/orderCart/ConnectedMenuContainer.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import LinearProgress from '@material-ui/core/LinearProgress';
 import { menuActions } from '../../redux/actions';
+
 
 import '../../../public/styles/cart_layout.scss';
 
@@ -61,11 +63,28 @@ class MenuContainer extends React.Component {
 
        <div className="flexbox">
 
-         <button className="btn btn-cart" onClick={this.placeOrder}>
+         { !this.props.connecting &&
+         <button
+           className="btn btn-cart"
+           onClick={this.placeOrder}
+           disabled={this.props.connecting}
+         >
               Post meals to Menu
          </button>
+       }
+         {this.props.connecting &&
+         <div style={{ width: '20%' }}>
+           <LinearProgress
+             style={{ height: '10px' }}
+           />
+         </div>
 
-         <button className="btn btn-cart" onClick={rest.clearMenu}>
+            }
+         <button
+           className="btn btn-cart"
+           onClick={rest.clearMenu}
+           disabled={this.props.connecting}
+         >
                    Clear Menu
          </button>
 
@@ -79,12 +98,14 @@ class MenuContainer extends React.Component {
 MenuContainer.defaultProps = {
   addClass: '',
   menuError: '',
+  connecting: false,
 };
 
 MenuContainer.propTypes = {
   menu: PropTypes.arrayOf(PropTypes.object).isRequired,
   addClass: PropTypes.string,
   menuError: PropTypes.string,
+  connecting: PropTypes.bool,
   clearMenu: PropTypes.func.isRequired,
   notify: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,


### PR DESCRIPTION
#### What does this PR do?
Adds a loading indicator to the menu cart
#### Description of Task to be completed?
Enable loading indicator when the menu is posted
#### How should this be manually tested?
```npm run test:server``` and ```npm run test:client```
#### Any background context you want to provide?
NA
#### What are the relevant pivotal tracker stories? (If applicable)
#160412932
#### Screenshots (If applicable)
NA