### PR TITLE
#160413548 add loading button to order cart

### DIFF
--- a/client/__tests__/components/__snapshots__/CartContainer.test.jsx.snap
+++ b/client/__tests__/components/__snapshots__/CartContainer.test.jsx.snap
@@ -107,6 +107,7 @@ exports[`CartContainer Component renders correctly 1`] = `
             </button>
             <button
               className="btn btn-cart"
+              disabled={false}
               onClick={[MockFunction]}
             >
               Clear Cart
@@ -226,6 +227,7 @@ exports[`CartContainer Component renders correctly 2`] = `
             </button>
             <button
               className="btn btn-cart"
+              disabled={false}
               onClick={[MockFunction]}
             >
               Clear Cart

--- a/client/src/components/orderCart/ConnectedCartContainer.jsx
+++ b/client/src/components/orderCart/ConnectedCartContainer.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import LinearProgress from '@material-ui/core/LinearProgress';
+
 import { connect } from 'react-redux';
 import { orderActions } from '../../redux/actions';
 
@@ -149,6 +151,8 @@ class CartContainer extends React.Component {
 
                <div className="flexbox info">
 
+                 {!this.state.placingOrder &&
+
                  <button
                    id="place-order"
                    className="btn btn-cart"
@@ -156,9 +160,20 @@ class CartContainer extends React.Component {
                    disabled={this.state.placingOrder}
                  >
                    {this.props.orderId ? 'Modify Order' : 'Place Order' }
-                 </button>
+                 </button>}
+                 {this.state.placingOrder &&
+                 <div style={{ width: '20%' }}>
+                   <LinearProgress
+                     style={{ height: '10px' }}
+                   />
+                 </div>
 
-                 <button className="btn btn-cart" onClick={rest.clearCart}>
+     }
+                 <button
+                   className="btn btn-cart"
+                   onClick={rest.clearCart}
+                   disabled={this.state.placingOrder}
+                 >
                    Clear Cart
                  </button>
 


### PR DESCRIPTION
#### What does this PR do?
Adds a loading indicator to the order cart
#### Description of Task to be completed?
Enable loading indicator when the order is posted
#### How should this be manually tested?
```npm run test:server``` and ```npm run test:client```
#### Any background context you want to provide?
NA
#### What are the relevant pivotal tracker stories? (If applicable)
#160413548
#### Screenshots (If applicable)
NA